### PR TITLE
fetch deputes photos more often

### DIFF
--- a/.github/workflows/fetch-deputes-photos.yaml
+++ b/.github/workflows/fetch-deputes-photos.yaml
@@ -3,7 +3,7 @@ name: Fetch deputes photos
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 3 * * 0' # every sunday at 3h
+    - cron: '0 3 * * *' # every day at 3h
 
 jobs:
   fetch:


### PR DESCRIPTION
Le job avait fail la semaine dernière parce qu'une des images de l'assemblée était temporairement en 404
Je pense qu'il faut lancer le job un peu plus souvent, comme ça on retombera sur nos pattes plus rapidement